### PR TITLE
fix: typo in online archive "custom criteria" resource example

### DIFF
--- a/website/docs/r/online_archive.html.markdown
+++ b/website/docs/r/online_archive.html.markdown
@@ -64,7 +64,7 @@ resource "mongodbatlas_online_archive" "test" {
         order      = 0 
     }
 
-    partitions_fields {
+    partition_fields {
         field_name = "secondName"
         order      = 1 
     }


### PR DESCRIPTION
## Description

Fixed typo in online archive "custom criteria" resource example -- correct attribute is `partition_fields`, not `partitions_fields`

Link to any related issue(s):

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue). Please, add the "bug" label to the PR.
- [ ] New feature (non-breaking change which adds functionality). Please, add the "enhancement" label to the PR.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected). Please, add the "breaking change" label to the PR.
- [ ] This change requires a documentation update
- [x] Documentation fix/enhancement

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have read the [contribution guidelines](https://github.com/mongodb/terraform-provider-mongodbatlas/blob/master/CONTRIBUTING.md)
- [ ] I have added tests that prove my fix is effective or that my feature works per HashiCorp requirements
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run make fmt and formatted my code

## Further comments
